### PR TITLE
fix: add documentation on substitution and shell variable expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,13 @@ rnr -f '(\w+)-(\d+).(\w+)' '${2}-${1}.${3}' ./*
 ├── 02-file.txt
 └── 03-file.txt
 ```
+__SHELL NOTE:__ In shells like Bash and zsh, make sure to wrap the `REPLACEMENT` pattern in single quotes. Otherwise, capture group indices will be replaced by expanded shell variables which will most likely be empty:
+```
+# Command typed in the shell
+rnr -f '(\w+)-(\d+).(\w+)' "${2}-${1}.${3}" ./*
+# After parameter expansion, the command that is actually ran:
+rnr -f '(\w+)-(\d+).(\w+)' "-." ./*
+```
 #### Capture several named groups and swap them
 1. Capture two digits as `number`.
 2. Capture extension as `ext`.

--- a/README.md
+++ b/README.md
@@ -478,13 +478,7 @@ rnr -f '(\w+)-(\d+).(\w+)' '${2}-${1}.${3}' ./*
 ├── 02-file.txt
 └── 03-file.txt
 ```
-__SHELL NOTE:__ In shells like Bash and zsh, make sure to wrap the `REPLACEMENT` pattern in single quotes. Otherwise, capture group indices will be replaced by expanded shell variables which will most likely be empty:
-```
-# Command typed in the shell
-rnr -f '(\w+)-(\d+).(\w+)' "${2}-${1}.${3}" ./*
-# After parameter expansion, the command that is actually ran:
-rnr -f '(\w+)-(\d+).(\w+)' "-." ./*
-```
+__SHELL NOTE:__ In shells like Bash and zsh, make sure to wrap the `REPLACEMENT` pattern in single quotes. Otherwise, capture group indices will be replaced by expanded shell variables.
 #### Capture several named groups and swap them
 1. Capture two digits as `number`.
 2. Capture extension as `ext`.

--- a/src/app.rs
+++ b/src/app.rs
@@ -88,7 +88,7 @@ pub fn create_app<'a>() -> App<'a, 'a> {
         )
         .arg(
             Arg::with_name("REPLACEMENT")
-                .help("Expression replacement. Enclose in single quotes to prevent variable expansion")
+                .help("Expression replacement (use single quotes for capture groups)")
                 .required(true)
                 .validator_os(is_valid_string)
                 .index(2),

--- a/src/app.rs
+++ b/src/app.rs
@@ -88,7 +88,7 @@ pub fn create_app<'a>() -> App<'a, 'a> {
         )
         .arg(
             Arg::with_name("REPLACEMENT")
-                .help("Expression replacement")
+                .help("Expression replacement. Enclose in single quotes to prevent variable expansion")
                 .required(true)
                 .validator_os(is_valid_string)
                 .index(2),


### PR DESCRIPTION
As discussed in #37. I've kept the explanation in `.help()` short to avoid either weird formatting or having to switch it to `.long_help()`.

Using double quotes for the REPLACEMENT argument with capture group substitution in shells like Bash or zsh will not work as intended. For example, a "${1}" will be replaced by the content of the shell variable 1 before rnr can read them, resulting in no substitution.